### PR TITLE
Fix Python version extraction regex for docker-borgmatic Dockerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         id: python_version
         run: |
           DOCKERFILE=$(curl -sf "https://raw.githubusercontent.com/modem7/docker-borgmatic/master/Dockerfile")
-          PY_VERSION=$(echo "$DOCKERFILE" | grep -oP '(?<=FROM python:)\d+\.\d+')
+          PY_VERSION=$(echo "$DOCKERFILE" | grep -oP '(?<=^ARG PYTHON_VERSION=)\d+\.\d+')
           CP_TAG="cp$(echo "$PY_VERSION" | tr -d '.')"
           echo "py_version=$PY_VERSION" >> $GITHUB_OUTPUT
           echo "cp_tag=$CP_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The `setup` job's "Fetch Python version from docker-borgmatic Dockerfile" step is failing on master and on #74 with `Process completed with exit code 1`.
- Root cause: the URL fix in 3d66052 corrected the path (docker-borgmatic moved its Dockerfile out of `base-fullbuild/`), but `docker-borgmatic`'s Dockerfile also changed how it declares the Python version — it now uses `ARG PYTHON_VERSION=3.14` + `FROM python:${PYTHON_VERSION}-alpine...` instead of a literal `FROM python:X.Y`. The old regex `(?<=FROM python:)\d+\.\d+` no longer matches anything, `grep` exits 1, and the step dies under `bash -e`.
- Fix: extract the version from the `ARG PYTHON_VERSION=` line instead.

## Test plan
- [x] Verified locally against the live Dockerfile: `curl -s https://raw.githubusercontent.com/modem7/docker-borgmatic/master/Dockerfile | grep -oP '(?<=^ARG PYTHON_VERSION=)\d+\.\d+'` returns `3.14`
- [ ] CI passes on this PR
- [ ] #74 rebased onto master picks up this fix and goes green