### PR TITLE
Align settings.yml with the current repo template

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,6 +2,7 @@
 # https://github.com/repository-settings/app
 
 repository:
+  name: cibuildwheel
   description: CIBuildWheel
   homepage: https://cloudsmith.io/~modem7/repos/wheels/packages/
   topics: cibuildwheel, python, wheel, pypi
@@ -11,44 +12,54 @@ repository:
   has_wiki: false
   has_downloads: true
   has_projects: false
+  has_discussions: false
 
   default_branch: master
 
   allow_squash_merge: true
   allow_rebase_merge: true
-  allow_merge_commit: false
-  
+  allow_merge_commit: true
+
+  # Auto-delete head branches after merge
+  delete_branch_on_merge: true
+
+  # Always suggest updating PR branches that are behind base
+  allow_update_branch: true
+
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
-  
+
+# Labels: define labels for Issues and Pull Requests
 labels:
-  - name: "bug"
-    color: "d73a4a"
+  - name: bug
+    color: d73a4a
     description: "Something isn't working"
-  - name: "dependencies"
-    color: "C62109"
+  - name: dependencies
+    color: C62109
     description: "Pull requests that update a dependency file"
-  - name: "documentation"
+  - name: documentation
     color: "0075ca"
     description: "Improvements or additions to documentation"
-  - name: "duplicate"
-    color: "cfd3d7"
+  - name: duplicate
+    color: cfd3d7
     description: "This issue or pull request already exists"
-  - name: "enhancement"
-    color: "a2eeef"
+  - name: enhancement
+    color: a2eeef
     description: "New feature or request"
-  - name: "good first issue"
+  - name: good first issue
     color: "7057ff"
     description: "Good for newcomers"
-  - name: "help wanted"
+  - name: help wanted
     color: "008672"
     description: "Extra attention is needed"
-  - name: "invalid"
-    color: "e4e669"
+  - name: invalid
+    color: e4e669
     description: "This doesn't seem right"
-  - name: "question"
-    color: "d876e3"
+  - name: question
+    color: d876e3
     description: "Further information is requested"
-  - name: "wontfix"
-    color: "#ffffff"
+  - name: wontfix
+    # was "#ffffff" in the uploaded file — leading # dropped, everything
+    # else in this list omits it and the app expects bare hex
+    color: ffffff
     description: "This will not be worked on"


### PR DESCRIPTION
## Summary
- This repo's `.github/settings.yml` was still on an older shape. Brought it in line with what other repos (docker-borgmatic, docker-rickroll, docker-starwars, crowdsec-troubleshooter, DefaultRepo) currently use: `name`, `has_discussions`, `delete_branch_on_merge`, `allow_update_branch`, `allow_merge_commit: true`, and cleaned-up label color formatting (including the `wontfix` color, which had a leading `#` that the Settings app was silently dropping).
- `description`, `homepage`, and `topics` left untouched.

## Test plan
- [ ] Merge and confirm the [Settings app](https://github.com/apps/settings) applies the new repo options and label colors without errors