### PR TITLE
Fix cloudsmith.sh path bug, bump manual scripts to cp314

### DIFF
--- a/borg_manylinux.sh
+++ b/borg_manylinux.sh
@@ -14,7 +14,7 @@ export CIBW_BEFORE_ALL='dnf install -y fuse glibc-devel pkgconf-pkg-config libac
 export CIBW_MANYLINUX_X86_64_IMAGE='quay.io/pypa/manylinux_2_28_x86_64'
 export CIBW_MANYLINUX_AARCH64_IMAGE='quay.io/pypa/manylinux_2_28_aarch64'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp313-manylinux_*'
+export CIBW_BUILD='cp314-manylinux_*'
 
 # Load Multiarch settings
 #docker run --rm --privileged tonistiigi/binfmt

--- a/borg_musllinux.sh
+++ b/borg_musllinux.sh
@@ -10,7 +10,7 @@ export PKGVER=$(grep "${PKGNAME}" requirements.txt | cut -d '=' -f 3 | tr -d '\0
 export PKGURL=$(curl -s "https://pypi.org/pypi/${PKGNAME}/${PKGVER}/json" | jq -r '.urls[].url')
 export CIBW_BEFORE_ALL='apk add -Uu acl-dev alpine-sdk attr-dev attr-dev bzip2-dev fuse-dev g++ openssl libffi-dev libssl3 libxxhash linux-headers lz4-dev musl-dev ncurses-dev openssl-dev py3-msgpack py3-packaging py3-pip py3-setuptools py3-setuptools_scm py3-wheel py3-xxhash python3-dev readline-dev sqlite-dev tree xxhash-dev xz-dev zlib-dev zstd-dev && pip install -U pkgconfig pip setuptools wheel'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp313-musllinux_*'
+export CIBW_BUILD='cp314-musllinux_*'
 
 # Load Multiarch settings
 docker run --rm --privileged tonistiigi/binfmt

--- a/cloudsmith.sh
+++ b/cloudsmith.sh
@@ -18,7 +18,7 @@ sudo python3 -m pip install -U cloudsmith-cli
 # Upload to Cloudsmith
 echo "==> Uploading wheels to Cloudsmith"
 cd wheelhouse/
-for f in wheelhouse/*.whl
+for f in *.whl
 do
   echo "Processing $f file..."
   cloudsmith push python -W -k $CLOUDSMITH_API --no-republish modem7/wheels "$f"
@@ -26,6 +26,6 @@ done
 
 # Deleting wheels
 echo "==> Deleting wheels now they've been uploaded"
-rm -rf wheelhouse/*.whl
+rm -rf *.whl
 
 exit 0

--- a/llfuse_manylinux.sh
+++ b/llfuse_manylinux.sh
@@ -10,7 +10,7 @@ export PKGVER=$(grep "${PKGNAME}" requirements.txt | cut -d '=' -f 3 | tr -d '\0
 export PKGURL=$(curl -s "https://pypi.org/pypi/${PKGNAME}/${PKGVER}/json" | jq -r '.urls[].url')
 export CIBW_BEFORE_ALL='yum install -y gcc-c++ fuse-devel pkgconfig && pip install -U pkgconfig pip setuptools wheel'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp313-manylinux_*'
+export CIBW_BUILD='cp314-manylinux_*'
 
 # Load Multiarch settings
 docker run --rm --privileged tonistiigi/binfmt

--- a/llfuse_musllinux.sh
+++ b/llfuse_musllinux.sh
@@ -10,7 +10,7 @@ export PKGVER=$(grep "${PKGNAME}" requirements.txt | cut -d '=' -f 3 | tr -d '\0
 export PKGURL=$(curl -s "https://pypi.org/pypi/${PKGNAME}/${PKGVER}/json" | jq -r '.urls[].url')
 export CIBW_BEFORE_ALL='apk add -Uu pkgconfig fuse-dev g++ && pip install -U pkgconfig pip setuptools wheel'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp313-musllinux_*'
+export CIBW_BUILD='cp314-musllinux_*'
 
 # Load Multiarch settings
 docker run --rm --privileged tonistiigi/binfmt

--- a/pyyaml.sh
+++ b/pyyaml.sh
@@ -10,7 +10,7 @@ export PKGVER=$(grep "${PKGNAME}" requirements.txt | cut -d '=' -f 3 | tr -d '\0
 export PKGURL=$(curl -s "https://pypi.org/pypi/${PKGNAME}/${PKGVER}/json" | jq -r '.urls[].url' | grep .tar.gz)
 export CIBW_BEFORE_ALL='apk add -Uu pkgconfig g++ yaml-dev python3-dev && pip install -U pkgconfig pip setuptools wheel'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp313-musllinux_*'
+export CIBW_BUILD='cp314-musllinux_*'
 export CIBW_ENVIRONMENT='C_INCLUDE_PATH=libyaml/include LIBRARY_PATH=libyaml/src/.libs LD_LIBRARY_PATH=libyaml/src/.libs PYYAML_FORCE_CYTHON=1 PYYAML_FORCE_LIBYAML=1'
 
 # Load Multiarch settings

--- a/ruamel.yaml.clib.sh
+++ b/ruamel.yaml.clib.sh
@@ -10,7 +10,7 @@ export PKGVER=$(grep "${PKGNAME}" requirements.txt | cut -d '=' -f 3 | tr -d '\0
 export PKGURL=$(curl -s "https://pypi.org/pypi/${PKGNAME}/${PKGVER}/json" | jq -r '.urls[].url' | grep .tar.gz)
 export CIBW_BEFORE_ALL='apk add -Uu pkgconfig gcc musl-dev && pip install -U pkgconfig pip setuptools wheel'
 export CIBW_ARCHS_LINUX='x86_64 aarch64'
-export CIBW_BUILD='cp312-musllinux_*'
+export CIBW_BUILD='cp314-musllinux_*'
 
 # Load Multiarch settings
 # docker run --rm --privileged tonistiigi/binfmt


### PR DESCRIPTION
## Summary
Audited this repo the same way I audited borgmatic-collective/pypi. Recipes and requirements.txt are already in sync here (this repo was the source of truth for that fix), but found two smaller issues:

- `cloudsmith.sh` `cd`'s into `wheelhouse/` but then globs `wheelhouse/*.whl` and `rm -rf wheelhouse/*.whl` — neither matches anything after the `cd`. Fixed to use the relative `*.whl` glob (already fixed in pypi's copy of this script, just never fixed in the original here).
- Manual local build scripts (`borg_manylinux.sh`, `borg_musllinux.sh`, `llfuse_manylinux.sh`, `llfuse_musllinux.sh`, `pyyaml.sh`, `ruamel.yaml.clib.sh`) were pinned to `cp313`/`cp312`, while `docker-borgmatic`'s Dockerfile is now on Python 3.14 — the automated CI build already tracks this dynamically, these manual scripts didn't. Bumped to `cp314`.

## Test plan
- [ ] Run one of the updated manual scripts locally (or via a manual `cibuildwheel` invocation) and confirm it targets cp314
- [ ] Manually run `cloudsmith.sh` against a test wheelhouse and confirm the glob now matches files