### PR TITLE
Extend shared renovate-config and settings defaults

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,4 @@
+_extends: .github
 # https://github.com/apps/settings
 # https://github.com/repository-settings/app
 
@@ -28,38 +29,3 @@ repository:
 
   enable_automated_security_fixes: true
   enable_vulnerability_alerts: true
-
-# Labels: define labels for Issues and Pull Requests
-labels:
-  - name: bug
-    color: d73a4a
-    description: "Something isn't working"
-  - name: dependencies
-    color: C62109
-    description: "Pull requests that update a dependency file"
-  - name: documentation
-    color: "0075ca"
-    description: "Improvements or additions to documentation"
-  - name: duplicate
-    color: cfd3d7
-    description: "This issue or pull request already exists"
-  - name: enhancement
-    color: a2eeef
-    description: "New feature or request"
-  - name: good first issue
-    color: "7057ff"
-    description: "Good for newcomers"
-  - name: help wanted
-    color: "008672"
-    description: "Extra attention is needed"
-  - name: invalid
-    color: e4e669
-    description: "This doesn't seem right"
-  - name: question
-    color: d876e3
-    description: "Further information is requested"
-  - name: wontfix
-    # was "#ffffff" in the uploaded file — leading # dropped, everything
-    # else in this list omits it and the app expects bare hex
-    color: ffffff
-    description: "This will not be worked on"

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "assignees": [
-    "modem7"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Europe/London"
+  "extends": ["github>modem7/renovate-config"]
 }


### PR DESCRIPTION
## Summary
- Replace the local `renovate.json` boilerplate with a one-line extend of the shared preset in `modem7/renovate-config`.
- Add `_extends: .github` to `.github/settings.yml` and drop the duplicated `labels:` array so labels are inherited from the account-wide defaults in `modem7/.github`.

This is part of a batch migration of ~15 of modem7's repos off duplicated Renovate/label boilerplate and onto centrally maintained shared config.

**Dependency note:** this depends on `modem7/renovate-config` PR #6 merging for the new `extends` target to take full effect. Until #6 merges, `github>modem7/renovate-config` still resolves to the current (pre-#6) config content, which is harmless — the extends reference itself is correct and validated successfully with `renovate-config-validator`.

## Test plan
- [x] `npx --yes -p renovate renovate-config-validator` → "Config validated successfully"
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/settings.yml'))"` → parses cleanly